### PR TITLE
feat(skills): add /synology-test + /synology-health + /synology-inventory skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,11 @@
+# mcp-synology Skills
+
+Live, operational skills shipped with the public mcp-synology MCP server.
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| synology-health | `/synology-health` | Traffic-light per-host dashboard (CPU, memory, disk, update availability) |
+| synology-inventory | `/synology-inventory` | Full per-host inventory (shares + volumes + iSCSI + users) |
+| synology-test | `/synology-test <host>` | Live-test every OSS tool, report to Slack |
+
+All skills require a working mcp-synology MCP server wired into the Claude Code session with the host's Vault credentials reachable.

--- a/.claude/skills/synology-health/SKILL.md
+++ b/.claude/skills/synology-health/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: synology-health
+description: Traffic-light health dashboard for one or more Synology hosts. CPU, memory, disk status, update availability, SMART warnings.
+disable-model-invocation: true
+---
+
+# /synology-health
+
+Quick health snapshot for every registered Synology host.
+
+## Usage
+
+```
+/synology-health [<host>]
+```
+
+- With `<host>`: check just that host.
+- Without: call `synology_host_list` and iterate every host.
+
+## Steps (per host)
+
+1. `synology_system_info` — record model, DSM version, uptime, CPU %, memory used %, temperature
+2. `synology_system_update_status` — updates available? If yes → ⚠️
+3. `synology_volume_list` — any volume with status != `normal`? → ⚠️ or ❌ depending on severity (degraded = ⚠️, crashed = ❌)
+4. `synology_diag_disk_health` — any disk with non-normal status? → ❌
+5. `synology_diag_smart` — any attribute with threshold violation? → ⚠️
+
+## Output
+
+Per host, one line with emoji (✅/⚠️/❌) + key metrics.
+Aggregate table across all hosts.
+If any ❌ → exit 1.
+
+## Example output
+
+```
+🟢 nas01 (DS1621+, DSM 7.2.1-69057, uptime 21d, CPU 4%, RAM 43%, temp 39°C)
+  ✅ update-status: up to date
+  ✅ volumes: 1 normal
+  ✅ disks: 4/4 healthy
+  ✅ smart: no warnings
+```
+
+## Cleanup
+
+Read-only skill — no mutations.

--- a/.claude/skills/synology-inventory/SKILL.md
+++ b/.claude/skills/synology-inventory/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: synology-inventory
+description: Full inventory of a Synology host — shares, volumes, iSCSI targets/LUNs, users, groups, packages. Markdown tables.
+disable-model-invocation: true
+---
+
+# /synology-inventory
+
+Full-picture inventory of one Synology host. Useful for audits, drift detection, capacity planning.
+
+## Usage
+
+```
+/synology-inventory <host>
+```
+
+## Steps
+
+1. Header — `synology_system_info` output (model, DSM version, serial, uptime)
+2. **Volumes** table — from `synology_volume_list`: ID, type, total, used, %, status
+3. **Shares** table — from `synology_share_list`: name, path, size used, encryption, quota
+4. **iSCSI** section:
+   - Targets table from `synology_iscsi_target_list`: IQN, enabled, mapped LUN count
+   - LUNs table from `synology_iscsi_lun_list`: name, size, location, mapped-to
+   - Initiator ACLs from `synology_iscsi_initiator_acl_list`
+5. **Users** table — from `synology_user_list`: name, uid, gid, description, disabled
+6. **Groups** table — from `synology_group_list`: name, gid, description
+7. **Packages** table — from `synology_package_list`: id, version, status
+8. **Network** — from `synology_network_interfaces`: interface, IP, MAC, MTU, link
+
+## Output
+
+Markdown, one section per area. Copy-pasteable into issues/docs.
+
+## Cleanup
+
+Read-only skill.

--- a/.claude/skills/synology-test/SKILL.md
+++ b/.claude/skills/synology-test/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: synology-test
+description: Live-test mcp-synology against a real Synology host. Exercises every read-only tool, reports pass/fail summary to Slack (C0ALHK18VC5).
+disable-model-invocation: true
+---
+
+# /synology-test
+
+Live-test every mcp-synology tool against the configured target Synology host.
+
+## Usage
+
+```
+/synology-test <host>
+```
+
+- `<host>` is the short hostname recognized by the HostRegistry (e.g. `nas01`). Defaults to the first host returned by `synology_host_list` if omitted.
+
+## Steps
+
+1. **Precheck** — call `synology_host_list` → expect the target host in the list.
+2. **System** — `synology_system_info` + `synology_system_update_status` → record DSM version, uptime, model.
+3. **Network** — `synology_network_interfaces` + `synology_network_routes` → expect at least one up interface, at least one default route.
+4. **Storage** — `synology_volume_list` → expect at least one volume in `normal` state. For each volume, `synology_volume_status`.
+5. **Shares** — `synology_share_list` → expect `proxmox` share present. `synology_share_permissions_get name=proxmox`.
+6. **Users/Groups** — `synology_user_list` + `synology_group_list` → expect `itsec` user present.
+7. **iSCSI** — `synology_iscsi_target_list` + `synology_iscsi_lun_list` + `synology_iscsi_initiator_acl_list` → record counts (may be zero; that's fine).
+8. **Snapshots** — `synology_snapshot_list share=proxmox` → record count.
+9. **Packages** — `synology_package_list` → expect `ScsiTarget` package present (since iSCSI tools need it).
+10. **Diag** — `synology_diag_disk_health` + `synology_diag_smart` + `synology_diag_log_tail lines=50`.
+
+## Output
+
+- Human table on stdout: one row per tool, ✅ / ⚠️ / ❌ + latency
+- Slack message to channel `C0ALHK18VC5` with summary (pass/fail counts, host name, DSM version)
+- Exit 0 if all ✅, 1 if any ❌
+
+## Bug reporting
+
+If any tool returns `isError: true` or an unexpected shape, file a GH issue in itunified-io/mcp-synology with label `bug` and the raw error text.
+
+## Cleanup
+
+This is a read-only skill. No state change on the NAS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented here. Format: [CalVer](https://calver.org/) — `YYYY.MM.DD.N`.
 
+## v2026.04.25.1
+
+### feat(skills): add /synology-test + /synology-health + /synology-inventory skills (#5)
+
+Three operational skills shipped with mcp-synology:
+- `/synology-test <host>` — live-test every read-only tool, report to Slack
+- `/synology-health [host]` — traffic-light health dashboard
+- `/synology-inventory <host>` — full Markdown inventory report
+
 ## v2026.04.23.1
 
 ### Initial release (#1)


### PR DESCRIPTION
Closes #5

Three operational skills shipped with mcp-synology:
- `/synology-test <host>` — live-test every read-only tool, report to Slack
- `/synology-health [host]` — traffic-light health dashboard
- `/synology-inventory <host>` — full Markdown inventory report

Skills follow ADR-0022 documentation standards with SKILL.md + README.md.