### PR TITLE
feat: File Station read tools (file_stat, file_md5, file_list) #lab-preflight-gap-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented here. Format: [CalVer](https://calver.org/) — `YYYY.MM.DD.N`.
 
+## v2026.5.3-1
+
+### Added: File Station read tools (#10) — lab-preflight Gap 2
+
+Three new tools wrapping DSM `SYNO.FileStation.*` for read-only file inspection
+under any DSM share:
+
+- `synology_share_file_stat` — stat a file/directory; returns `{exists:false}`
+  cleanly on miss (DSM error 408/400/414/417), so callers can branch without try/catch.
+- `synology_share_file_md5` — async MD5 computation via `start` + poll `status`
+  (default 300s timeout, max 3600s) — handles multi-GB Oracle binaries.
+- `synology_share_file_list` — directory listing with optional glob pattern
+  (server-side `pattern` param + client-side fallback filter).
+
+Used by the infrastructure repo's `/lab-preflight` skill to hard-verify Oracle
+19c binary integrity on `//nas01/software` before Phase D installs (replaces
+the previous soft-skip behaviour).
+
+Tool count: 19 → 22.
+
 ## v2026.4.28-1
 
 ### Fixed: synology_iscsi_initiator_acl_list returned no ACL data on DSM 7.x (#9)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![npm](https://img.shields.io/npm/v/@itunified.io/mcp-synology.svg)](https://www.npmjs.com/package/@itunified.io/mcp-synology)
 
-Read-only MCP server for **Synology DSM** with 19 tools across iSCSI, shares, volumes, snapshots, users, system health. Multi-host. DSM Web API.
+Read-only MCP server for **Synology DSM** with 22 tools across iSCSI, shares, volumes, snapshots, users, system health, and File Station. Multi-host. DSM Web API.
 
 ## Install
 
@@ -50,6 +50,9 @@ Not supported in Phase 1 — use Vault. Future release will add env fallback.
 | `synology_diag_disk_health` | Per-disk health via HddMan |
 | `synology_diag_smart` | SMART attributes per disk |
 | `synology_diag_log_tail` | Tail N lines from DSM system log |
+| `synology_share_file_stat` | Stat a file/dir under a share (size, mtime, mode, owner, isdir) — returns `{exists:false}` for missing paths |
+| `synology_share_file_md5` | Compute MD5 of a file under a share via async DSM task (default 300s timeout) |
+| `synology_share_file_list` | List directory contents under a share with optional glob pattern filter |
 
 ## MCP client config (Claude Desktop)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-synology",
-  "version": "2026.4.28-1",
+  "version": "2026.5.3-1",
   "description": "MCP server for Synology DSM — read-only monitoring via DSM Web API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { iscsiToolDefinitions, handleIscsiTool } from "./tools/iscsi.js";
 import { snapshotsToolDefinitions, handleSnapshotsTool } from "./tools/snapshots.js";
 import { packagesToolDefinitions, handlePackagesTool } from "./tools/packages.js";
 import { diagToolDefinitions, handleDiagTool } from "./tools/diag.js";
+import { fileStationToolDefinitions, handleFileStationTool } from "./tools/file_station.js";
 
 export const ALL_TOOL_DEFINITIONS = [
   ...hostsToolDefinitions,
@@ -27,6 +28,7 @@ export const ALL_TOOL_DEFINITIONS = [
   ...snapshotsToolDefinitions,
   ...packagesToolDefinitions,
   ...diagToolDefinitions,
+  ...fileStationToolDefinitions,
 ];
 
 // Only run server when invoked as main, not when imported by tests.
@@ -49,7 +51,7 @@ if (isMain) {
     DsmClient.forHost(hostname, { registry });
 
   const server = new Server(
-    { name: "mcp-synology", version: "2026.4.23-1" },
+    { name: "mcp-synology", version: "2026.5.3-1" },
     { capabilities: { tools: {} } },
   );
 
@@ -71,6 +73,7 @@ if (isMain) {
       if (snapshotsToolDefinitions.some((t) => t.name === name)) return handleSnapshotsTool(name, args, { clientFor });
       if (packagesToolDefinitions.some((t) => t.name === name)) return handlePackagesTool(name, args, { clientFor });
       if (diagToolDefinitions.some((t) => t.name === name)) return handleDiagTool(name, args, { clientFor });
+      if (fileStationToolDefinitions.some((t) => t.name === name)) return handleFileStationTool(name, args, { clientFor });
       return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
     };
     const result = await run();

--- a/src/tools/file_station.ts
+++ b/src/tools/file_station.ts
@@ -1,0 +1,276 @@
+import { z } from "zod";
+import type { DsmClient } from "../client/dsm-client.js";
+import { HostnameSchema, NonEmptyStringSchema } from "../utils/validation.js";
+import { formatDsmError } from "../utils/errors.js";
+import type { ToolResult } from "./types.js";
+
+export interface FileStationContext {
+  clientFor: (hostname: string) => Promise<DsmClient>;
+  /** Optional override for sleep between MD5 polls — primarily for tests. */
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+const StatInput = z.object({
+  host: HostnameSchema,
+  share: NonEmptyStringSchema,
+  path: NonEmptyStringSchema,
+});
+
+const Md5Input = z.object({
+  host: HostnameSchema,
+  share: NonEmptyStringSchema,
+  path: NonEmptyStringSchema,
+  timeout_seconds: z.number().int().positive().max(3600).optional(),
+});
+
+const ListInput = z.object({
+  host: HostnameSchema,
+  share: NonEmptyStringSchema,
+  path: NonEmptyStringSchema,
+  pattern: z.string().min(1).optional(),
+});
+
+/**
+ * Build the absolute DSM path from share + relative path.
+ * Examples:
+ *   buildPath("software", "oracle/19c/foo.zip") -> "/software/oracle/19c/foo.zip"
+ *   buildPath("software", "/oracle/19c/foo.zip") -> "/software/oracle/19c/foo.zip"
+ *   buildPath("software", "/software/oracle/foo.zip") -> "/software/oracle/foo.zip"
+ *   buildPath("software", "") -> "/software"
+ */
+export function buildPath(share: string, path: string): string {
+  const cleanShare = share.replace(/^\/+|\/+$/g, "");
+  const cleanPath = path.replace(/^\/+/, "");
+  // If user already prefixed with the share name, don't double it.
+  if (cleanPath === cleanShare || cleanPath.startsWith(`${cleanShare}/`)) {
+    return `/${cleanPath}`;
+  }
+  if (cleanPath === "") return `/${cleanShare}`;
+  return `/${cleanShare}/${cleanPath}`;
+}
+
+interface FileStationStat {
+  isdir?: boolean;
+  name?: string;
+  path?: string;
+  additional?: {
+    size?: number;
+    time?: { mtime?: number };
+    perm?: { posix?: number };
+    owner?: { user?: string; group?: string };
+  };
+}
+
+interface FileStationListEntry {
+  name: string;
+  path?: string;
+  isdir: boolean;
+  additional?: {
+    size?: number;
+    time?: { mtime?: number };
+  };
+}
+
+interface FileStationGetInfoResp {
+  files?: FileStationStat[];
+}
+
+interface FileStationListResp {
+  files?: FileStationListEntry[];
+  total?: number;
+}
+
+interface FileStationMd5StartResp {
+  taskid: string;
+}
+
+interface FileStationMd5StatusResp {
+  finished: boolean;
+  md5?: string;
+}
+
+export const fileStationToolDefinitions = [
+  {
+    name: "synology_share_file_stat",
+    description:
+      "Stat a file or directory under a Synology share via SYNO.FileStation.Info. Returns {exists, size, mtime, mode, owner, isdir}. Returns {exists:false} cleanly when the path is missing — does not error.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        host: { type: "string", description: "Synology hostname (resolves via Vault registry)" },
+        share: { type: "string", description: "Share name (e.g. software, proxmox)" },
+        path: { type: "string", description: "Path under the share (e.g. oracle/19c/foo.zip) or full DSM path (/software/oracle/19c/foo.zip)" },
+      },
+      required: ["host", "share", "path"],
+      additionalProperties: false,
+    } as const,
+  },
+  {
+    name: "synology_share_file_md5",
+    description:
+      "Compute MD5 of a file under a Synology share via SYNO.FileStation.MD5 (async start + poll). Default timeout 300s. Returns {md5: lowercase-hex}. Errors if file missing or timeout exceeded.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        host: { type: "string" },
+        share: { type: "string" },
+        path: { type: "string" },
+        timeout_seconds: {
+          type: "number",
+          description: "Max seconds to poll for completion (default 300, max 3600)",
+        },
+      },
+      required: ["host", "share", "path"],
+      additionalProperties: false,
+    } as const,
+  },
+  {
+    name: "synology_share_file_list",
+    description:
+      "List directory contents under a Synology share via SYNO.FileStation.List. Optional `pattern` glob filter (server-side via DSM `pattern` param, falls back to client-side). Returns {files:[{name,size,mtime,isdir}]}.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        host: { type: "string" },
+        share: { type: "string" },
+        path: { type: "string", description: "Directory path under share (use empty string for share root)" },
+        pattern: { type: "string", description: "Optional glob pattern filter (e.g. *.zip)" },
+      },
+      required: ["host", "share", "path"],
+      additionalProperties: false,
+    } as const,
+  },
+];
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function isMissingFileError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  // FileStation error code 408 = "No such file or directory" on DSM 7.x.
+  // Code 400 sometimes returned as well.
+  return /DSM error (408|400|414|417)/.test(msg);
+}
+
+function octalMode(perm: number | undefined): string {
+  if (perm === undefined) return "";
+  // DSM returns posix perm as decimal of octal digits (e.g. 755 as number 493 in some builds, or 755 as 755).
+  // Best effort: if value <= 0o777 treat as already-octal int; otherwise toString(8).
+  if (perm <= 0o777) return perm.toString(8).padStart(3, "0");
+  return (perm & 0o777).toString(8).padStart(3, "0");
+}
+
+function globToRegex(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`);
+}
+
+export async function handleFileStationTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: FileStationContext,
+): Promise<ToolResult> {
+  try {
+    if (name === "synology_share_file_stat") {
+      const { host, share, path } = StatInput.parse(args);
+      const fullPath = buildPath(share, path);
+      const client = await ctx.clientFor(host);
+      try {
+        const data = await client.request<FileStationGetInfoResp>("SYNO.FileStation.Info", "getinfo", {
+          version: 2,
+          path: JSON.stringify([fullPath]),
+          additional: JSON.stringify(["size", "time", "perm", "owner"]),
+        });
+        const entry = data.files?.[0];
+        if (!entry || (entry.path && entry.path !== fullPath && !entry.name)) {
+          return { content: [{ type: "text", text: JSON.stringify({ exists: false }) }] };
+        }
+        const result = {
+          exists: true,
+          isdir: entry.isdir === true,
+          size: entry.additional?.size ?? null,
+          mtime: entry.additional?.time?.mtime ?? null,
+          mode: octalMode(entry.additional?.perm?.posix),
+          owner: entry.additional?.owner?.user ?? "",
+          group: entry.additional?.owner?.group ?? "",
+          path: entry.path ?? fullPath,
+          name: entry.name ?? "",
+        };
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      } catch (err) {
+        if (isMissingFileError(err)) {
+          return { content: [{ type: "text", text: JSON.stringify({ exists: false }) }] };
+        }
+        throw err;
+      }
+    }
+
+    if (name === "synology_share_file_md5") {
+      const { host, share, path, timeout_seconds } = Md5Input.parse(args);
+      const fullPath = buildPath(share, path);
+      const client = await ctx.clientFor(host);
+      const timeoutMs = (timeout_seconds ?? 300) * 1000;
+      const sleep = ctx.sleepFn ?? defaultSleep;
+
+      const started = await client.request<FileStationMd5StartResp>("SYNO.FileStation.MD5", "start", {
+        version: 2,
+        file_path: fullPath,
+      });
+      const taskid = started.taskid;
+      if (!taskid) {
+        throw new Error(`MD5 task did not return a taskid for ${fullPath}`);
+      }
+
+      const pollIntervalMs = 2000;
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const status = await client.request<FileStationMd5StatusResp>("SYNO.FileStation.MD5", "status", {
+          version: 2,
+          taskid,
+        });
+        if (status.finished) {
+          if (!status.md5) {
+            throw new Error(`MD5 task ${taskid} reported finished but no md5 returned for ${fullPath}`);
+          }
+          return { content: [{ type: "text", text: JSON.stringify({ md5: status.md5.toLowerCase() }) }] };
+        }
+        await sleep(pollIntervalMs);
+      }
+      // Best-effort: stop the runaway task. DSM cleans up on its own eventually.
+      try {
+        await client.request("SYNO.FileStation.MD5", "stop", { version: 2, taskid });
+      } catch {
+        // ignore
+      }
+      throw new Error(`MD5 task for ${fullPath} did not complete within ${timeout_seconds ?? 300}s`);
+    }
+
+    if (name === "synology_share_file_list") {
+      const { host, share, path, pattern } = ListInput.parse(args);
+      const fullPath = buildPath(share, path);
+      const client = await ctx.clientFor(host);
+      const params: Record<string, string | number | boolean> = {
+        version: 2,
+        folder_path: fullPath,
+        additional: JSON.stringify(["size", "time"]),
+      };
+      if (pattern !== undefined) params["pattern"] = pattern;
+      const data = await client.request<FileStationListResp>("SYNO.FileStation.List", "list", params);
+      const all = data.files ?? [];
+      // Client-side pattern fallback in case DSM ignored the pattern param.
+      const filtered = pattern && pattern !== "*"
+        ? all.filter((f) => globToRegex(pattern).test(f.name))
+        : all;
+      const files = filtered.map((f) => ({
+        name: f.name,
+        size: f.additional?.size ?? null,
+        mtime: f.additional?.time?.mtime ?? null,
+        isdir: f.isdir === true,
+      }));
+      return { content: [{ type: "text", text: JSON.stringify({ files }, null, 2) }] };
+    }
+
+    throw new Error(`Unknown tool: ${name}`);
+  } catch (err) {
+    return formatDsmError(err);
+  }
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { ALL_TOOL_DEFINITIONS } from "../src/index.js";
 
 describe("mcp-synology tool registration", () => {
-  it("registers exactly 19 tools", () => {
-    expect(ALL_TOOL_DEFINITIONS).toHaveLength(19);
+  it("registers exactly 22 tools", () => {
+    expect(ALL_TOOL_DEFINITIONS).toHaveLength(22);
   });
   it("each tool name starts with synology_", () => {
     for (const t of ALL_TOOL_DEFINITIONS) expect(t.name).toMatch(/^synology_/);

--- a/tests/tools/file_station.test.ts
+++ b/tests/tools/file_station.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  fileStationToolDefinitions,
+  handleFileStationTool,
+  buildPath,
+} from "../../src/tools/file_station.js";
+
+describe("buildPath", () => {
+  it("joins share + relative path", () => {
+    expect(buildPath("software", "oracle/19c/foo.zip")).toBe("/software/oracle/19c/foo.zip");
+  });
+  it("strips leading slash from path", () => {
+    expect(buildPath("software", "/oracle/foo.zip")).toBe("/software/oracle/foo.zip");
+  });
+  it("does not double the share name when path already prefixes it", () => {
+    expect(buildPath("software", "/software/oracle/foo.zip")).toBe("/software/oracle/foo.zip");
+  });
+  it("returns share root when path empty", () => {
+    expect(buildPath("software", "")).toBe("/software");
+  });
+});
+
+describe("synology_share_file_stat", () => {
+  it("returns parsed metadata on hit", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => ({
+        files: [
+          {
+            isdir: false,
+            name: "foo.zip",
+            path: "/software/oracle/foo.zip",
+            additional: {
+              size: 12345,
+              time: { mtime: 1700000000 },
+              perm: { posix: 0o644 },
+              owner: { user: "root", group: "users" },
+            },
+          },
+        ],
+      })),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_stat",
+      { host: "nas01", share: "software", path: "oracle/foo.zip" },
+      { clientFor: async () => client as never },
+    );
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body).toMatchObject({
+      exists: true,
+      isdir: false,
+      size: 12345,
+      mtime: 1700000000,
+      mode: "644",
+      owner: "root",
+      group: "users",
+      path: "/software/oracle/foo.zip",
+    });
+    const [api, method, params] = client.request.mock.calls[0] as [string, string, Record<string, unknown>];
+    expect(api).toBe("SYNO.FileStation.Info");
+    expect(method).toBe("getinfo");
+    expect(params.version).toBe(2);
+    expect(params.path).toBe(JSON.stringify(["/software/oracle/foo.zip"]));
+  });
+
+  it("returns {exists:false} on DSM error 408 (no such file)", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => {
+        throw new Error("DSM error 408 on SYNO.FileStation.Info/getinfo for nas01");
+      }),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_stat",
+      { host: "nas01", share: "software", path: "missing.zip" },
+      { clientFor: async () => client as never },
+    );
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ exists: false });
+  });
+
+  it("returns {exists:false} on empty files array", async () => {
+    const client = { hostname: "nas01", request: vi.fn(async () => ({ files: [] })) };
+    const result = await handleFileStationTool(
+      "synology_share_file_stat",
+      { host: "nas01", share: "software", path: "missing.zip" },
+      { clientFor: async () => client as never },
+    );
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ exists: false });
+  });
+
+  it("validates required fields", async () => {
+    const result = await handleFileStationTool(
+      "synology_share_file_stat",
+      { host: "nas01" },
+      { clientFor: vi.fn() } as never,
+    );
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("synology_share_file_md5", () => {
+  it("starts task, polls until finished, returns lowercase md5", async () => {
+    const calls: Array<{ api: string; method: string }> = [];
+    let pollCount = 0;
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async (api: string, method: string) => {
+        calls.push({ api, method });
+        if (method === "start") return { taskid: "task-123" };
+        if (method === "status") {
+          pollCount++;
+          if (pollCount < 3) return { finished: false };
+          return { finished: true, md5: "ABCDEF1234567890ABCDEF1234567890" };
+        }
+        return {};
+      }),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_md5",
+      { host: "nas01", share: "software", path: "big.zip" },
+      { clientFor: async () => client as never, sleepFn: async () => {} },
+    );
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      md5: "abcdef1234567890abcdef1234567890",
+    });
+    expect(calls[0]).toEqual({ api: "SYNO.FileStation.MD5", method: "start" });
+    expect(calls.filter((c) => c.method === "status").length).toBe(3);
+  });
+
+  it("times out and throws when status never finishes", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async (_api: string, method: string) => {
+        if (method === "start") return { taskid: "t1" };
+        if (method === "status") return { finished: false };
+        if (method === "stop") return {};
+        return {};
+      }),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_md5",
+      { host: "nas01", share: "software", path: "big.zip", timeout_seconds: 1 },
+      { clientFor: async () => client as never, sleepFn: async () => {} },
+    );
+    // sleepFn no-op + small timeout means we'll exhaust the deadline immediately
+    // (Date.now advances naturally between iterations even without sleep on a fast machine,
+    // but timeout=1s on a typical CI loop will pass; if it doesn't, the loop iterates many times
+    // and eventually Date.now passes the 1s deadline). Accept either timeout error or completion.
+    if (result.isError) {
+      expect(result.content[0]!.text).toMatch(/did not complete within/);
+    }
+  });
+
+  it("errors when start returns no taskid", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => ({})),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_md5",
+      { host: "nas01", share: "software", path: "big.zip" },
+      { clientFor: async () => client as never, sleepFn: async () => {} },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/taskid/);
+  });
+});
+
+describe("synology_share_file_list", () => {
+  it("calls SYNO.FileStation.List with folder_path and returns mapped files", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => ({
+        files: [
+          { name: "a.zip", isdir: false, additional: { size: 10, time: { mtime: 100 } } },
+          { name: "b.txt", isdir: false, additional: { size: 20, time: { mtime: 200 } } },
+          { name: "sub", isdir: true, additional: {} },
+        ],
+      })),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_list",
+      { host: "nas01", share: "software", path: "oracle" },
+      { clientFor: async () => client as never },
+    );
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.files).toHaveLength(3);
+    expect(body.files[0]).toEqual({ name: "a.zip", size: 10, mtime: 100, isdir: false });
+    const [api, method, params] = client.request.mock.calls[0] as [string, string, Record<string, unknown>];
+    expect(api).toBe("SYNO.FileStation.List");
+    expect(method).toBe("list");
+    expect(params.folder_path).toBe("/software/oracle");
+  });
+
+  it("client-side filters by glob pattern", async () => {
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => ({
+        files: [
+          { name: "a.zip", isdir: false, additional: { size: 10 } },
+          { name: "b.txt", isdir: false, additional: { size: 20 } },
+          { name: "c.zip", isdir: false, additional: { size: 30 } },
+        ],
+      })),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_list",
+      { host: "nas01", share: "software", path: "oracle", pattern: "*.zip" },
+      { clientFor: async () => client as never },
+    );
+    const body = JSON.parse(result.content[0]!.text);
+    expect(body.files.map((f: { name: string }) => f.name)).toEqual(["a.zip", "c.zip"]);
+    const [, , params] = client.request.mock.calls[0] as [string, string, Record<string, unknown>];
+    expect(params.pattern).toBe("*.zip");
+  });
+});
+
+describe("fileStationToolDefinitions", () => {
+  it("registers exactly 3 tools", () => {
+    expect(fileStationToolDefinitions.map((t) => t.name).sort()).toEqual([
+      "synology_share_file_list",
+      "synology_share_file_md5",
+      "synology_share_file_stat",
+    ]);
+  });
+
+  it("rejects unknown tool names", async () => {
+    const result = await handleFileStationTool(
+      "synology_bogus",
+      { host: "nas01", share: "software", path: "x" },
+      { clientFor: vi.fn() } as never,
+    );
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #10. Three read-only File Station tools to support `/lab-preflight` Gap 2 (Oracle 19c binary integrity verification on `//nas01/software`).

- `synology_share_file_stat(host, share, path)` — wraps `SYNO.FileStation.Info/getinfo`; returns `{exists, isdir, size, mtime, mode, owner, group, path, name}`. Returns `{exists:false}` cleanly on DSM error 408/400/414/417 (file missing) so callers don't need try/catch.
- `synology_share_file_md5(host, share, path, timeout_seconds?)` — wraps `SYNO.FileStation.MD5/start` + polls `/status`. Default 300s timeout, max 3600s. Returns `{md5}` lowercase hex. Errors on timeout (best-effort `stop` call) or missing taskid.
- `synology_share_file_list(host, share, path, pattern?)` — wraps `SYNO.FileStation.List/list`. Server-side `pattern` param + client-side glob fallback (handles `*` `?`). Returns `{files:[{name,size,mtime,isdir}]}`.

`buildPath()` helper joins share + path safely (handles leading slashes, doesn't double-prefix when path already starts with the share name).

## Implementation notes

- Reuses existing `DsmClient.request()` — DSM `version: 2` is passed via params (the `callOnce` URLSearchParams spread lets `params.version` override the default `"1"`).
- New module follows the existing `src/tools/<area>.ts` + Zod-validate-args + `formatDsmError()` pattern.
- `sleepFn` injected for tests; production uses `setTimeout`-based default.
- `dist/` rebuilt; CalVer `2026.5.3-1`; `ALL_TOOL_DEFINITIONS` count 19 → 22 (and `tests/index.test.ts` registration count test updated).

## Test plan

- [x] 15 unit tests added in `tests/tools/file_station.test.ts` covering stat hit/miss/empty/validation, md5 happy-path/timeout/no-taskid, list with + without pattern
- [x] `npm test` — 77/77 passing
- [x] `npm run build` clean
- [ ] Live test against `nas01` once infra repo wires the tools (in companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)