### PR TITLE
fix(file_station): real DSM 7.x response shapes — file_stat + file_md5 (#12 v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project are documented here. Format: [CalVer](https://calver.org/) — `YYYY.MM.DD.N`.
 
+## v2026.5.3-3
+
+### Fixed: File Station tools now match real DSM 7.x response shapes (#12 v2)
+
+`v2026.5.3-2` corrected method names but assumed the wrong API for stat and
+mis-encoded the permission field. Live probing against `nas01` (DSM 7.2,
+2026-05-03) revealed the actual shapes:
+
+- **`file_stat`** — `SYNO.FileStation.Info.get` is the FileStation
+  *user-session* endpoint (returns `{uid, hostname, items, ...}`); it has
+  nothing to do with file metadata. The correct endpoint on DSM 7.x is
+  `SYNO.FileStation.List.getinfo`. Discovered via `SYNO.API.Info` enumeration —
+  `SYNO.FileStation.GetInfo` does **not** exist on DSM 7.x.
+- **Missing-path detection** — `List.getinfo` does **not** raise DSM error 408
+  for missing paths. It returns a placeholder entry with empty `name` and no
+  `additional` block. We now detect that and return `{exists:false}` cleanly.
+- **`mode` formatting** — DSM returns `posix` as the literal decimal of the
+  octal digits (e.g. `posix: 777` for `0o777`), not as the value of `0o777`.
+  The previous `(perm).toString(8)` produced `"1411"` for `777`. Now passes
+  the value through unchanged with zero-padding.
+- **`file_md5` 599 tolerance** — DSM returns error 599 ("Unknown DSM error")
+  on `status` polls when another MD5 task is in flight on the same session,
+  and *also* on any poll after a task reports `finished:true`. We now treat
+  599 from `status` as transient and keep polling until either a real
+  finished result or the per-call timeout (default 300s). The arbitrary
+  1500ms initial-delay-before-first-poll has been removed — clean cycles
+  complete in ~1s for a 72MB file.
+
+### Live verification (2026-05-03, nas01 DSM 7.2)
+
+- `synology_share_file_stat /software/oracle/19/opatch/12.2.0.1.47/p6880880_190000_Linux-x86-64.zip`
+  → `exists:true, size:72847006, mtime:1753730601, mode:"777", owner:"itsec"`
+- `synology_share_file_md5` (same path)
+  → `c6d2d850687528ccf943c4acdfc758c4` (completes in ~1s)
+- Missing path → `{exists:false}` (no error)
+
+### Tests
+
+83 unit tests pass. Added: 599-tolerance poll test, missing-path placeholder
+detection test. Updated: stat test now expects `SYNO.FileStation.List.getinfo`
+and `posix: 644` (decimal-of-octal, not `0o644`).
+
 ## v2026.5.3-2
 
 ### Fixed: File Station path-handling bugs (#12)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itunified.io/mcp-synology",
-  "version": "2026.5.3-2",
+  "version": "2026.5.3-3",
   "description": "MCP server for Synology DSM — read-only monitoring via DSM Web API",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/probe-filestation.ts
+++ b/scripts/probe-filestation.ts
@@ -10,7 +10,7 @@ import https from "node:https";
 
 const HOST = process.argv[2] ?? "nas01";
 
-const VAULT_ADDR = process.env.NAS_VAULT_ADDR ?? "https://nas01:8443";
+const VAULT_ADDR = process.env.NAS_VAULT_ADDR ?? "https://vault.int.itunified.io";
 const ROLE_ID = process.env.NAS_VAULT_ROLE_ID_MCP_SYNOLOGY ?? process.env.NAS_VAULT_ROLE_ID_MCP_SYNOLOGY_ENTERPRISE!;
 const SECRET_ID = process.env.NAS_VAULT_SECRET_ID_MCP_SYNOLOGY ?? process.env.NAS_VAULT_SECRET_ID_MCP_SYNOLOGY_ENTERPRISE!;
 
@@ -71,23 +71,50 @@ async function main() {
   const TEST_FILE = "/software/oracle/19/opatch/12.2.0.1.47/p6880880_190000_Linux-x86-64.zip";
   const TEST_DIR = "/software/oracle/19/grid_home";
 
-  // 1. Bug 1 verify: SYNO.FileStation.Info method=get vs getinfo
-  for (const method of ["getinfo", "get"]) {
+  // 1. Bug 1 verify: try multiple Info variants — method=get vs getinfo, path JSON-array vs string,
+  //    api SYNO.FileStation.Info vs SYNO.FileStation.GetInfo (DSM 6.x legacy).
+  const variants: Array<{ tag: string; api: string; method: string; pathParam: string }> = [
+    { tag: "Info.get path=JSON-array",       api: "SYNO.FileStation.Info",    method: "get",     pathParam: JSON.stringify([TEST_FILE]) },
+    { tag: "Info.get path=string",           api: "SYNO.FileStation.Info",    method: "get",     pathParam: TEST_FILE },
+    { tag: "Info.getinfo path=JSON-array",   api: "SYNO.FileStation.Info",    method: "getinfo", pathParam: JSON.stringify([TEST_FILE]) },
+    { tag: "Info.getinfo path=string",       api: "SYNO.FileStation.Info",    method: "getinfo", pathParam: TEST_FILE },
+    { tag: "GetInfo.getinfo path=JSON-array",api: "SYNO.FileStation.GetInfo", method: "getinfo", pathParam: JSON.stringify([TEST_FILE]) },
+  ];
+  for (const v of variants) {
     const u = `${dsmUrl}/webapi/entry.cgi?` +
       new URLSearchParams({
-        api: "SYNO.FileStation.Info",
-        method,
+        api: v.api,
+        method: v.method,
         version: "2",
-        path: JSON.stringify([TEST_FILE]),
-        additional: JSON.stringify(["size", "time"]),
+        path: v.pathParam,
+        additional: JSON.stringify(["size", "time", "perm", "owner"]),
       }).toString();
     const r = await fetch(u, { headers: { Cookie: cookie } });
-    const b = (await r.json()) as { success: boolean; data?: unknown; error?: { code: number } };
-    console.log(`[probe] Info.${method} → success=${b.success} code=${b.error?.code ?? "—"}`);
-    if (b.success) {
-      const f = (b.data as { files?: Array<{ name: string; additional?: { size?: number } }> }).files?.[0];
-      console.log(`          name=${f?.name} size=${f?.additional?.size}`);
-    }
+    const b = await r.json() as Record<string, unknown>;
+    console.log(`[probe] ${v.tag}\n          ${JSON.stringify(b)}`);
+  }
+
+  // 1b. Discover all FileStation APIs
+  const apiInfoUrl = `${dsmUrl}/webapi/entry.cgi?` +
+    new URLSearchParams({ api: "SYNO.API.Info", method: "query", version: "1", query: "all" }).toString();
+  const apiInfoRes = await fetch(apiInfoUrl, { headers: { Cookie: cookie } });
+  const apiInfoBody = await apiInfoRes.json() as { data?: Record<string, unknown> };
+  const fsApis = Object.keys(apiInfoBody.data ?? {}).filter(k => k.startsWith("SYNO.FileStation"));
+  console.log(`[probe] FileStation APIs available:\n          ${fsApis.join("\n          ")}`);
+
+  // 1c. Try the *actual* file-info methods documented in older DSM SDK
+  const moreVariants: Array<{ tag: string; api: string; method: string; extra?: Record<string,string> }> = [
+    { tag: "FileStation.GetInfo.get path=JSON-array",   api: "SYNO.FileStation.GetInfo",   method: "get",     extra: { path: JSON.stringify([TEST_FILE]) } },
+    { tag: "FileStation.GetInfo.getinfo path=JSON",     api: "SYNO.FileStation.GetInfo",   method: "getinfo", extra: { path: JSON.stringify([TEST_FILE]) } },
+    { tag: "FileStation.List.getinfo path=JSON-array",  api: "SYNO.FileStation.List",      method: "getinfo", extra: { path: JSON.stringify([TEST_FILE]) } },
+    { tag: "FileStation.List.getinfo path=string",      api: "SYNO.FileStation.List",      method: "getinfo", extra: { path: TEST_FILE } },
+  ];
+  for (const v of moreVariants) {
+    const u = `${dsmUrl}/webapi/entry.cgi?` +
+      new URLSearchParams({ api: v.api, method: v.method, version: "2", additional: JSON.stringify(["size","time","perm","owner"]), ...v.extra }).toString();
+    const r = await fetch(u, { headers: { Cookie: cookie } });
+    const b = await r.json();
+    console.log(`[probe] ${v.tag}\n          ${JSON.stringify(b).slice(0,500)}`);
   }
 
   // 2. Bug 2 verify: MD5 start + status poll
@@ -100,7 +127,7 @@ async function main() {
     }).toString();
   const startRes = await fetch(startUrl, { headers: { Cookie: cookie } });
   const startBody = (await startRes.json()) as { success: boolean; data?: { taskid?: string }; error?: { code: number } };
-  console.log(`[probe] MD5.start → success=${startBody.success} taskid=${startBody.data?.taskid?.slice(0, 16) ?? "—"}`);
+  console.log(`[probe] MD5.start RAW → ${JSON.stringify(startBody)}`);
   if (!startBody.success || !startBody.data?.taskid) throw new Error(`MD5 start failed: ${JSON.stringify(startBody)}`);
   const taskid = startBody.data.taskid;
 
@@ -109,7 +136,69 @@ async function main() {
     new URLSearchParams({ api: "SYNO.FileStation.MD5", method: "status", version: "2", taskid }).toString();
   const ir = await fetch(immediateStatus, { headers: { Cookie: cookie } });
   const ib = (await ir.json()) as { success: boolean; error?: { code: number }; data?: { finished?: boolean; md5?: string } };
-  console.log(`[probe] MD5.status (immediate) → success=${ib.success} code=${ib.error?.code ?? "—"} finished=${ib.data?.finished}`);
+  console.log(`[probe] MD5.status v2 (immediate) RAW → ${JSON.stringify(ib)}`);
+
+  // Try alternative status shapes
+  const altStatusVariants: Array<{ tag: string; params: Record<string,string> }> = [
+    { tag: "MD5.status v=1 taskid",      params: { api: "SYNO.FileStation.MD5", method: "status", version: "1", taskid } },
+    { tag: "MD5.getinfo v=2 taskid",     params: { api: "SYNO.FileStation.MD5", method: "getinfo", version: "2", taskid } },
+    { tag: "MD5.status v=2 file_path",   params: { api: "SYNO.FileStation.MD5", method: "status", version: "2", taskid, file_path: TEST_FILE } },
+  ];
+  for (const v of altStatusVariants) {
+    const u = `${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams(v.params).toString();
+    const r = await fetch(u, { headers: { Cookie: cookie } });
+    const b = await r.json();
+    console.log(`[probe] ${v.tag} → ${JSON.stringify(b)}`);
+  }
+
+  // 2b. Re-start MD5 and list BackgroundTask to see real task status
+  const start2 = await fetch(`${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+    api: "SYNO.FileStation.MD5", method: "start", version: "2", file_path: TEST_FILE,
+  }).toString(), { headers: { Cookie: cookie } });
+  const start2Body = await start2.json() as { data?: { taskid?: string } };
+  const tid2 = start2Body.data?.taskid;
+  console.log(`[probe] MD5.start #2 → taskid=${tid2}`);
+
+  for (const ms of [500, 2000, 5000, 10000, 20000, 30000]) {
+    await new Promise(r => setTimeout(r, ms));
+    const sr = await fetch(`${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+      api: "SYNO.FileStation.MD5", method: "status", version: "2", taskid: tid2!,
+    }).toString(), { headers: { Cookie: cookie } });
+    const sb = await sr.json();
+    console.log(`[probe] +${ms}ms MD5.status → ${JSON.stringify(sb)}`);
+  }
+
+  // 2c. BackgroundTask.list
+  const btUrl = `${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+    api: "SYNO.FileStation.BackgroundTask", method: "list", version: "3",
+  }).toString();
+  const btRes = await fetch(btUrl, { headers: { Cookie: cookie } });
+  const btBody = await btRes.json();
+  console.log(`[probe] BackgroundTask.list → ${JSON.stringify(btBody).slice(0,800)}`);
+
+  // 2d. Stop any in-flight, then a CLEAN single MD5 cycle
+  if (tid2) {
+    await fetch(`${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+      api: "SYNO.FileStation.MD5", method: "stop", version: "2", taskid: tid2,
+    }).toString(), { headers: { Cookie: cookie } });
+  }
+  await new Promise(r => setTimeout(r, 2000));
+  console.log(`[probe] === CLEAN cycle — fresh MD5 task ===`);
+  const cleanStart = await fetch(`${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+    api: "SYNO.FileStation.MD5", method: "start", version: "2", file_path: TEST_FILE,
+  }).toString(), { headers: { Cookie: cookie } });
+  const cleanBody = await cleanStart.json() as { data?: { taskid?: string } };
+  const cleanTid = cleanBody.data?.taskid!;
+  console.log(`[probe] clean MD5.start → ${cleanTid}`);
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    const sr = await fetch(`${dsmUrl}/webapi/entry.cgi?` + new URLSearchParams({
+      api: "SYNO.FileStation.MD5", method: "status", version: "2", taskid: cleanTid,
+    }).toString(), { headers: { Cookie: cookie } });
+    const sb = await sr.json() as { success: boolean; data?: { finished?: boolean; md5?: string }; error?: { code: number } };
+    console.log(`[probe] +${i+1}s clean MD5.status → ${JSON.stringify(sb)}`);
+    if (sb.success && sb.data?.finished) break;
+  }
 
   // Now wait 1.5s and poll.
   await new Promise((r) => setTimeout(r, 1500));
@@ -118,13 +207,10 @@ async function main() {
   while (Date.now() < deadline) {
     const sr = await fetch(immediateStatus, { headers: { Cookie: cookie } });
     const sb = (await sr.json()) as { success: boolean; error?: { code: number }; data?: { finished?: boolean; md5?: string } };
-    if (!sb.success) {
-      console.log(`[probe] MD5.status (after delay) → ERROR code=${sb.error?.code}`);
-      break;
-    }
+    console.log(`[probe] MD5.status (poll) RAW → ${JSON.stringify(sb)}`);
+    if (!sb.success) break;
     if (sb.data?.finished) {
       finalMd5 = sb.data.md5;
-      console.log(`[probe] MD5.status → finished, md5=${finalMd5}`);
       break;
     }
     await new Promise((r) => setTimeout(r, 2000));

--- a/src/tools/file_station.ts
+++ b/src/tools/file_station.ts
@@ -153,10 +153,11 @@ function isMissingFileError(err: unknown): boolean {
 
 function octalMode(perm: number | undefined): string {
   if (perm === undefined) return "";
-  // DSM returns posix perm as decimal of octal digits (e.g. 755 as number 493 in some builds, or 755 as 755).
-  // Best effort: if value <= 0o777 treat as already-octal int; otherwise toString(8).
-  if (perm <= 0o777) return perm.toString(8).padStart(3, "0");
-  return (perm & 0o777).toString(8).padStart(3, "0");
+  // DSM 7.x returns posix perm as the literal decimal of the octal digits — i.e. 0o755 is sent as
+  // the integer 755 (NOT 0o755 = 493). Verified live against DSM 7.2 on 2026-05-03 (#12 v2 probe):
+  // a 0o777 file came back as `posix: 777`.
+  // We render the value as-is, zero-padded to 3 digits.
+  return String(perm).padStart(3, "0");
 }
 
 function globToRegex(glob: string): RegExp {
@@ -175,14 +176,19 @@ export async function handleFileStationTool(
       const fullPath = buildPath(share, path);
       const client = await ctx.clientFor(host);
       try {
-        // DSM 7.x SYNO.FileStation.Info uses method=get (DSM 5.x used getinfo).
-        const data = await client.request<FileStationGetInfoResp>("SYNO.FileStation.Info", "get", {
+        // DSM 7.x: file stat is SYNO.FileStation.List method=getinfo.
+        // SYNO.FileStation.Info.get returns FileStation user-session info, NOT file info.
+        // Verified live against DSM 7.2 / nas01 on 2026-05-03 (#12 v2 probe).
+        const data = await client.request<FileStationGetInfoResp>("SYNO.FileStation.List", "getinfo", {
           version: 2,
           path: JSON.stringify([fullPath]),
           additional: JSON.stringify(["size", "time", "perm", "owner"]),
         });
         const entry = data.files?.[0];
-        if (!entry || (entry.path && entry.path !== fullPath && !entry.name)) {
+        // DSM 7.x `SYNO.FileStation.List.getinfo` does NOT raise an error for missing paths;
+        // it returns a placeholder entry with empty `name` and no `additional`. Treat that as
+        // not-found. Verified live against DSM 7.2 on 2026-05-03 (#12 v2 probe).
+        if (!entry || (!entry.name && !entry.additional)) {
           return { content: [{ type: "text", text: JSON.stringify({ exists: false }) }] };
         }
         const result = {
@@ -221,23 +227,38 @@ export async function handleFileStationTool(
         throw new Error(`MD5 task did not return a taskid for ${fullPath}`);
       }
 
-      const pollIntervalMs = 2000;
-      // DSM returns error 599 ("Unknown DSM error") if status is polled immediately
-      // after start — give the task time to register before the first poll.
-      const initialDelayMs = 1500;
-      await sleep(initialDelayMs);
+      const pollIntervalMs = 1000;
       const deadline = Date.now() + timeoutMs;
+      // DSM allows only ONE concurrent MD5 task per session. If a stale task is in flight,
+      // status polls return error 599 ("Unknown DSM error"). Treat 599 as transient: keep
+      // polling until either a real finished result or the timeout.
+      // Verified live against DSM 7.2 on 2026-05-03 (#12 v2 probe) — clean cycles complete
+      // in ~1s for a 72MB file.
+      let consecutive599 = 0;
+      const max599 = Math.max(10, Math.ceil(timeoutMs / pollIntervalMs));
       while (Date.now() < deadline) {
-        // Status poll MUST send only taskid (no path) — DSM rejects the path param here.
-        const status = await client.request<FileStationMd5StatusResp>("SYNO.FileStation.MD5", "status", {
-          version: 2,
-          taskid,
-        });
-        if (status.finished) {
-          if (!status.md5) {
-            throw new Error(`MD5 task ${taskid} reported finished but no md5 returned for ${fullPath}`);
+        try {
+          const status = await client.request<FileStationMd5StatusResp>("SYNO.FileStation.MD5", "status", {
+            version: 2,
+            taskid,
+          });
+          consecutive599 = 0;
+          if (status.finished) {
+            if (!status.md5) {
+              throw new Error(`MD5 task ${taskid} reported finished but no md5 returned for ${fullPath}`);
+            }
+            return { content: [{ type: "text", text: JSON.stringify({ md5: status.md5.toLowerCase() }) }] };
           }
-          return { content: [{ type: "text", text: JSON.stringify({ md5: status.md5.toLowerCase() }) }] };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (/DSM error 599/.test(msg)) {
+            consecutive599 += 1;
+            if (consecutive599 > max599) {
+              throw new Error(`MD5 task ${taskid} returned DSM error 599 repeatedly — another MD5 task may be in flight on this session`);
+            }
+          } else {
+            throw err;
+          }
         }
         await sleep(pollIntervalMs);
       }

--- a/tests/tools/file_station.test.ts
+++ b/tests/tools/file_station.test.ts
@@ -33,7 +33,7 @@ describe("synology_share_file_stat", () => {
             additional: {
               size: 12345,
               time: { mtime: 1700000000 },
-              perm: { posix: 0o644 },
+              perm: { posix: 644 },
               owner: { user: "root", group: "users" },
             },
           },
@@ -58,8 +58,8 @@ describe("synology_share_file_stat", () => {
       path: "/software/oracle/foo.zip",
     });
     const [api, method, params] = client.request.mock.calls[0] as [string, string, Record<string, unknown>];
-    expect(api).toBe("SYNO.FileStation.Info");
-    expect(method).toBe("get");
+    expect(api).toBe("SYNO.FileStation.List");
+    expect(method).toBe("getinfo");
     expect(params.version).toBe(2);
     expect(params.path).toBe(JSON.stringify(["/software/oracle/foo.zip"]));
   });
@@ -68,7 +68,7 @@ describe("synology_share_file_stat", () => {
     const client = {
       hostname: "nas01",
       request: vi.fn(async () => {
-        throw new Error("DSM error 408 on SYNO.FileStation.Info/get for nas01");
+        throw new Error("DSM error 408 on SYNO.FileStation.List/getinfo for nas01");
       }),
     };
     const result = await handleFileStationTool(
@@ -77,6 +77,22 @@ describe("synology_share_file_stat", () => {
       { clientFor: async () => client as never },
     );
     expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ exists: false });
+  });
+
+  it("returns {exists:false} on placeholder entry (DSM 7.x missing-path response)", async () => {
+    // DSM 7.x `List.getinfo` returns a stub entry {name:"", path:"/...", isdir:false} for missing paths.
+    const client = {
+      hostname: "nas01",
+      request: vi.fn(async () => ({
+        files: [{ name: "", path: "/software/missing.zip", isdir: false }],
+      })),
+    };
+    const result = await handleFileStationTool(
+      "synology_share_file_stat",
+      { host: "nas01", share: "software", path: "missing.zip" },
+      { clientFor: async () => client as never },
+    );
     expect(JSON.parse(result.content[0]!.text)).toEqual({ exists: false });
   });
 
@@ -182,29 +198,31 @@ describe("synology_share_file_md5", () => {
     expect("file_path" in first).toBe(false);
   });
 
-  it("waits an initial delay before first status poll", async () => {
-    const sleeps: number[] = [];
+  it("treats DSM error 599 from status as transient and keeps polling", async () => {
+    let statusCalls = 0;
     const client = {
       hostname: "nas01",
       request: vi.fn(async (_api: string, method: string) => {
         if (method === "start") return { taskid: "t" };
-        if (method === "status") return { finished: true, md5: "abc" };
+        if (method === "status") {
+          statusCalls += 1;
+          if (statusCalls < 3) {
+            // DSM returns 599 while a prior task still occupies the session — recoverable.
+            throw new Error("DSM error 599 on SYNO.FileStation.MD5/status for nas01");
+          }
+          return { finished: true, md5: "feedface" };
+        }
         return {};
       }),
     };
-    await handleFileStationTool(
+    const result = await handleFileStationTool(
       "synology_share_file_md5",
       { host: "nas01", share: "software", path: "x" },
-      {
-        clientFor: async () => client as never,
-        sleepFn: async (ms: number) => {
-          sleeps.push(ms);
-        },
-      },
+      { clientFor: async () => client as never, sleepFn: async () => {} },
     );
-    // First sleep should be the initial delay (≥1000ms) before any status poll.
-    expect(sleeps.length).toBeGreaterThan(0);
-    expect(sleeps[0]).toBeGreaterThanOrEqual(1000);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ md5: "feedface" });
+    expect(statusCalls).toBe(3);
   });
 
   it("normalizes both relative and absolute path forms in start", async () => {


### PR DESCRIPTION
## Summary

`v2026.5.3-2` was an incomplete fix: it corrected method names but kept the
**wrong API** for `file_stat` and mis-encoded `mode`. This PR fixes the bugs
based on **live DSM 7.2 probe results** (nas01, 2026-05-03), not assumptions.

Closes #12 (v2 attempt).

## Real DSM 7.x response shapes (probed live)

Captured from `scripts/probe-filestation.ts nas01`:

| Variant | Result |
|---|---|
| `SYNO.FileStation.Info.get path=JSON-array` | `{data:{uid:1032,hostname:"nas01",items:[{gid:100},...],...},success:true}` ← **user-session, not file info** |
| `SYNO.FileStation.Info.getinfo` | `{error:{code:103},success:false}` |
| `SYNO.FileStation.GetInfo.*` | `{error:{code:102},success:false}` ← API does not exist on DSM 7.x |
| **`SYNO.FileStation.List.getinfo`** | `{data:{files:[{name:"p6880880_190000_Linux-x86-64.zip",path:"/software/...",isdir:false,additional:{owner:{user:"itsec",...},perm:{posix:777,...},size:72847006,time:{mtime:1753730601}}}]},success:true}` ✅ |
| `List.getinfo` on missing path | `{data:{files:[{name:"",path:"/...",isdir:false}]},success:true}` ← stub entry, no error |
| `MD5.start` | `{data:{taskid:"1777..."},success:true}` |
| `MD5.status` (clean session) | `{data:{finished:true,md5:"c6d2d850687528ccf943c4acdfc758c4"},success:true}` at +1s |
| `MD5.status` (concurrent task or post-finish) | `{error:{code:599},success:false}` |

## Fixes

1. **`file_stat`** → switched to `SYNO.FileStation.List.getinfo`
2. **Missing-path detection** → checks for empty `name` + missing `additional`
3. **`mode`** → DSM returns posix as decimal-of-octal digits (777, not `0o777` = 511); pass through with zero-padding
4. **`file_md5`** → 599 from `status` is transient (another task in flight, or stale-after-finished); keep polling. Removed the unnecessary 1500ms initial-delay-before-first-poll.

## Live verification (post-fix)

```
=== file_stat (existing file) ===
{"exists":true,"isdir":false,"size":72847006,"mtime":1753730601,"mode":"777","owner":"itsec","group":"users","path":"/software/oracle/19/opatch/12.2.0.1.47/p6880880_190000_Linux-x86-64.zip","name":"p6880880_190000_Linux-x86-64.zip"}

=== file_stat (missing file) ===
{"exists":false}

=== file_md5 (existing file) ===
[file_md5] start → {"taskid":"1777799652CD8D3A04"}
[file_md5] status → {"finished":false}
[file_md5] status → {"finished":true,"md5":"c6d2d850687528ccf943c4acdfc758c4"}
{"md5":"c6d2d850687528ccf943c4acdfc758c4"}
```

**Confirmed MD5 of `p6880880_190000_Linux-x86-64.zip` = `c6d2d850687528ccf943c4acdfc758c4`**

## Test plan

- [x] 83 unit tests pass (added 599-tolerance + missing-path placeholder tests; updated stat test to assert `List.getinfo` + decimal posix)
- [x] `npm run build` clean
- [x] Live verified against nas01 DSM 7.2: `file_stat`, `file_md5`, missing-path
- [ ] Operator review before merge
- [ ] After merge: `npm publish`, infra `/lab-preflight ext3+ext4` re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)